### PR TITLE
DTSPO-5577 - add git commit timestamp to image tag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,8 @@ stages:
           - bash: |
               repo_sha=$(git rev-parse --verify HEAD)
               docker_image_tag_sha=${repo_sha:0:7}
-              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]${docker_image_tag_sha}"
+              last_commit_time=$(git log -1 --pretty='%cd' --date=iso | tr -d '+[:space:]:-' | head -c 14)
+              echo "##vso[task.setvariable variable=DOCKER_TAG;isOutput=true]${docker_image_tag_sha}-${last_commit_time}"
             displayName: 'Get Docker Tag'
             name: 'getDockerTag'
           - task: Docker@1


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5577


### Change description ###
- Added last git commit timestamp to image tag to enable image automation on flux v2


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
